### PR TITLE
Allow address strings with multiple URIs (e.g., when auto_sm is used)

### DIFF
--- a/include/hermes/async_engine.hpp
+++ b/include/hermes/async_engine.hpp
@@ -217,7 +217,7 @@ public:
         // the transport protocol used by the engine
         const auto pos = addr.rfind("://");
 
-        if(pos != std::string::npos) {
+        if (pos != std::string::npos) {
             // multiple URIs may be part of address string (e.g., if auto_sm is used)
             auto pos_delim = addr.rfind(';');
             std::string transport_substr{};
@@ -225,10 +225,12 @@ public:
                 // auto_sm address is used
                 assert(pos_delim < pos);
                 transport_substr = addr.substr(pos_delim + 1, (pos - pos_delim) + 2);
-            } else
+            }
+            else {
                 transport_substr = addr.substr(0, pos + 3);
+            }
 
-            if(transport_substr != get_transport_lookup_prefix(m_transport)) {
+            if (transport_substr != get_transport_lookup_prefix(m_transport)) {
                 throw std::runtime_error("Transport protocol provided by address "
                                          "does not match engine's configured "
                                          "tranport");
@@ -236,7 +238,7 @@ public:
         }
 
         const std::string transport_address(
-                pos != std::string::npos ?  addr :
+                pos != std::string::npos ? addr :
                 get_transport_lookup_prefix(m_transport) + addr);
 
         {

--- a/include/hermes/async_engine.hpp
+++ b/include/hermes/async_engine.hpp
@@ -219,7 +219,12 @@ public:
 
         if (pos != std::string::npos) {
             // multiple URIs may be part of address string (e.g., if auto_sm is used)
-            auto pos_delim = addr.rfind(';');
+            // address delimiter defined in private Mercury header: src/mercury_core.c
+            auto pos_delim = addr.rfind('#');
+            if (pos_delim == std::string::npos) {
+                // try address delimiter of older Mercury versions
+                pos_delim = addr.rfind(';');
+            }
             std::string transport_substr{};
             if (pos_delim != std::string::npos) {
                 // auto_sm address is used

--- a/include/hermes/async_engine.hpp
+++ b/include/hermes/async_engine.hpp
@@ -215,11 +215,20 @@ public:
 
         // if address contains a prefix, make sure that it matches 
         // the transport protocol used by the engine
-
-        const std::size_t pos = addr.find("://");
+        const auto pos = addr.rfind("://");
 
         if(pos != std::string::npos) {
-            if(addr.substr(0, pos+3) != get_transport_lookup_prefix(m_transport)) {
+            // multiple URIs may be part of address string (e.g., if auto_sm is used)
+            auto pos_delim = addr.rfind(';');
+            std::string transport_substr{};
+            if (pos_delim != std::string::npos) {
+                // auto_sm address is used
+                assert(pos_delim < pos);
+                transport_substr = addr.substr(pos_delim + 1, (pos - pos_delim) + 2);
+            } else
+                transport_substr = addr.substr(0, pos + 3);
+
+            if(transport_substr != get_transport_lookup_prefix(m_transport)) {
                 throw std::runtime_error("Transport protocol provided by address "
                                          "does not match engine's configured "
                                          "tranport");


### PR DESCRIPTION
When auto_sm is used the address string consists of multiple URIs: gid, na+sm, and the chosen transport layer (semicolon separated).

This pull request changes the check if the correct address string is used with multiple URIs.