### PR TITLE
Adding missing header for recent Mercury versions

### DIFF
--- a/include/hermes/detail/mercury_utils.hpp
+++ b/include/hermes/detail/mercury_utils.hpp
@@ -3,6 +3,7 @@
 
 // C includes
 #include <mercury.h>
+#include <mercury_log.h>
 
 // project includes
 #include <hermes/logging.hpp>


### PR DESCRIPTION
Compiling with the latest Mercury versions fails repeatedly with the following error:
```
In file included from /home/vef/m1_gekkofs/external/hermes/include/hermes/exposed_memory.hpp:21:0,
                 from /home/vef/m1_gekkofs/external/hermes/include/hermes/async_engine.hpp:28,
                 from /home/vef/m1_gekkofs/external/hermes/include/hermes.hpp:4,
                 from /home/vef/m1_gekkofs/include/client/preload_context.hpp:17,
                 from /home/vef/m1_gekkofs/include/client/preload.hpp:17,
                 from /home/vef/m1_gekkofs/src/client/rpc/forward_metadata.cpp:15:
/home/vef/m1_gekkofs/external/hermes/include/hermes/detail/mercury_utils.hpp: In function ‘void hermes::detail::set_mercury_log_function(int (*)(FILE*, const char*, ...))’:
/home/vef/m1_gekkofs/external/hermes/include/hermes/detail/mercury_utils.hpp:89:5: error: ‘::hg_log_set_func’ has not been declared
     ::hg_log_set_func(fn);
     ^~
```

Mercury removed the reference to `mercury_log.h` so that `hg_log_set_func()` can no longer be referenced.

This patch fixes this by explicitly adding the `mercury_log.h` header. 