### PR TITLE
Fixing transport metadata for psm2

### DIFF
--- a/include/hermes/transport.hpp
+++ b/include/hermes/transport.hpp
@@ -114,7 +114,7 @@ std::array<
     std::make_tuple(
             transport::ofi_psm2,
             "ofi+psm2://",
-            "ofi+psm2://fi_addr_psmx2://"
+            "ofi+psm2://"
             ),
     std::make_tuple(
             transport::ofi_gni,


### PR DESCRIPTION
The lookup format for `ofi+psm2` changed a while ago. Unfortunately, the Mercury documentation does not reflect this at the moment.

This patch fixes the lookup prefix to the currently used one.