### PR TITLE
Fixing ofi+verbs support for latest Mercury version

### DIFF
--- a/include/hermes/async_engine.hpp
+++ b/include/hermes/async_engine.hpp
@@ -238,9 +238,14 @@ public:
             }
             std::string transport_substr{};
             if (pos_delim != std::string::npos) {
-                // auto_sm address is used
-                assert(pos_delim < pos);
-                transport_substr = addr.substr(pos_delim + 1, (pos - pos_delim) + 2);
+                // handle ofi+verbs special cases which uses the `;` character: ofi+verbs;ofi_rxm://
+                if (m_transport == transport::ofi_verbs) {
+                    transport_substr = addr.substr(0, pos_delim) + addr.substr(pos, 3);
+                } else {
+                    // auto_sm address is used
+                    assert(pos_delim < pos);
+                    transport_substr = addr.substr(pos_delim + 1, (pos - pos_delim) + 2);
+                }
             }
             else {
                 transport_substr = addr.substr(0, pos + 3);

--- a/include/hermes/transport.hpp
+++ b/include/hermes/transport.hpp
@@ -109,7 +109,7 @@ std::array<
     std::make_tuple(
             transport::ofi_verbs,
             "ofi+verbs://",
-            "ofi+verbs;ofi_rxm://fi_sockaddr_in://"
+            "ofi+verbs://"
             ),
     std::make_tuple(
             transport::ofi_psm2,


### PR DESCRIPTION
When Mercury is started with `ofi+verbs`, the following self address is returned: `ofi+verbs;ofi_rxm://` (which is also put into the GekkoFS hosts file). The lookup prefix, however, is `ofi+verbs://`.

Currently, the `;` separator is used for older Mercury versions to separate URIs, e.g., when auto_sm is used. For `ofi+verbs` the same separator is used but for another context.

 This patch removes `;ofi_rxm` from the lookup address. In addition, the lookup prefix has been updated to reflect these changes. 