### PR TITLE
Adding force_no_block_progress to engine_options

### DIFF
--- a/include/hermes/async_engine.hpp
+++ b/include/hermes/async_engine.hpp
@@ -99,8 +99,7 @@ public:
         m_transport(transport_type) {
 
         // IMPORTANT: this struct needs to be zeroed before use
-        struct hg_init_info hg_options;
-        std::memset(&hg_options, 0, sizeof(hg_options));
+        struct hg_init_info hg_options = HG_INIT_INFO_INITIALIZER;
 
         if(opts & use_auto_sm) {
             hg_options.auto_sm = HG_TRUE;
@@ -110,7 +109,11 @@ public:
             hg_options.stats = HG_TRUE;
         }
 
-        m_hg_class = 
+        if (opts & force_no_block_progress) {
+            hg_options.na_init_info.progress_mode = NA_NO_BLOCK;
+        }
+
+        m_hg_class =
                 detail::initialize_mercury(
                         get_transport_prefix(m_transport), 
                         bind_address, 

--- a/include/hermes/options.hpp
+++ b/include/hermes/options.hpp
@@ -7,6 +7,7 @@ enum __engine_opts {
     __none             = 0,
     __use_auto_sm      = 1L << 0,
     __print_stats      = 1L << 1,
+    __force_no_block_progress = 1L << 2,
     __engine_opts_end = 1L << 16,
     __engine_opts_max = __INT_MAX__,
     __engine_opts_min = ~__INT_MAX__
@@ -51,6 +52,7 @@ using engine_options = __engine_opts;
 
 static const constexpr engine_options none = __engine_opts::__none;
 static const constexpr engine_options use_auto_sm = __engine_opts::__use_auto_sm;
+static const constexpr engine_options force_no_block_progress = __engine_opts::__force_no_block_progress;
 static const constexpr engine_options print_stats = __engine_opts::__print_stats;
 
 } // namespace hermes


### PR DESCRIPTION
This is primarily used for psm2 which doesn't work without it if the client doesn't enable it.
It is kept in engine_opts as future Mercury version will set no block progress by default for psm2.

More info here: https://github.com/mercury-hpc/mercury/issues/356