### PR TITLE
gcc11 warning fix: Use reference instead of copy in loop

### DIFF
--- a/include/hermes/async_engine.hpp
+++ b/include/hermes/async_engine.hpp
@@ -353,7 +353,7 @@ public:
         // TODO: this waits on each individual lookup. Make it so that
         // all lookups are posted to mercury and we only wait once on
         // total completion
-        for(const auto addr : unique_addrs) {
+        for(const auto& addr : unique_addrs) {
             endps.emplace_back(lookup(addr));
         }
 


### PR DESCRIPTION
Newer gcc versions (e.g., gcc11) produce this warning:
```
In file included from /tmp/tmp.T49eCAtQQl/external/hermes/include/hermes.hpp:4,
                 from /tmp/tmp.T49eCAtQQl/include/client/preload_context.hpp:33,
                 from /tmp/tmp.T49eCAtQQl/include/client/preload.hpp:33,
                 from /tmp/tmp.T49eCAtQQl/src/client/intercept.cpp:31:
/tmp/tmp.T49eCAtQQl/external/hermes/include/hermes/async_engine.hpp: In member function 'hermes::endpoint_set hermes::async_engine::lookup(std::initializer_list<std::__cxx11::basic_string<char> >&&) const':
/tmp/tmp.T49eCAtQQl/external/hermes/include/hermes/async_engine.hpp:356:24: warning: loop variable 'addr' creates a copy from type 'const std::__cxx11::basic_string<char>' [-Wrange-loop-construct]
  356 |         for(const auto addr : unique_addrs) {
      |                        ^~~~
/tmp/tmp.T49eCAtQQl/external/hermes/include/hermes/async_engine.hpp:356:24: note: use reference type to prevent copying
  356 |         for(const auto addr : unique_addrs) {
      |                        ^~~~
      |      
```

This fix solves this issue.