### PR TITLE
Include missing <array> to fix GCC 12.1 errors.

### DIFF
--- a/include/hermes/async_engine.hpp
+++ b/include/hermes/async_engine.hpp
@@ -15,6 +15,7 @@
 #include <chrono>
 #include <algorithm>
 #include <cstring>
+#include <array>
 
 // C includes
 #include <mercury.h>


### PR DESCRIPTION
Closes #12.