### PR TITLE
Margo-hg-shim support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,7 +91,9 @@ if(HERMES_LOGGING)
 endif()
 
 if(HERMES_MARGO_COMPATIBLE_RPCS)
+  find_package(Margo-hg-shim REQUIRED)
   target_compile_definitions(hermes INTERFACE HERMES_MARGO_COMPATIBLE_MODE)
+  target_link_libraries(hermes INTERFACE Margo::Margo-hg-shim)
 endif()
 
 if(HERMES_BUILD_EXAMPLES)

--- a/cmake/FindMargo-hg-shim.cmake
+++ b/cmake/FindMargo-hg-shim.cmake
@@ -1,0 +1,181 @@
+#[=======================================================================[.rst:
+FindMargo-hg-shim
+---------
+
+Find Margo shim library include dirs and libraries.
+
+Use this module by invoking find_package with the form::
+
+  find_package(Margo-hg-shim
+    [version] [EXACT]     # Minimum or EXACT version e.g. 0.6.2
+    [REQUIRED]            # Fail with error if Margo is not found
+    )
+
+Imported Targets
+^^^^^^^^^^^^^^^^
+
+This module provides the following imported targets, if found:
+
+``Margo::Margo-hg-shim``
+  The Margo-hg-shim library
+
+Result Variables
+^^^^^^^^^^^^^^^^
+
+This will define the following variables:
+
+``Margo-hg-shim_FOUND``
+  True if the system has the Margo-hg-shim library.
+``Margo_hg_shim_VERSION``
+  The version of the Margo-hg-shim library which was found.
+``Margo_HG_SHIM_INCLUDE_DIRS``
+  Include directories needed to use Margo-hg-shim.
+``Margo_HG_SHIM_LIBRARIES``
+  Libraries needed to link to Margo-hg-shim.
+
+Cache Variables
+^^^^^^^^^^^^^^^
+
+The following cache variables may also be set:
+
+``Margo_HG_SHIM_INCLUDE_DIR``
+  The directory containing ``margo.h``.
+``Margo_HG_SHIM_LIBRARY``
+  The path to the Margo library.
+
+#]=======================================================================]
+
+function(_get_pkgconfig_paths target_var)
+  set(_lib_dirs)
+  if (NOT DEFINED CMAKE_SYSTEM_NAME
+      OR (CMAKE_SYSTEM_NAME MATCHES "^(Linux|kFreeBSD|GNU)$"
+      AND NOT CMAKE_CROSSCOMPILING)
+      )
+    if (EXISTS "/etc/debian_version") # is this a debian system ?
+      if (CMAKE_LIBRARY_ARCHITECTURE)
+        list(APPEND _lib_dirs "lib/${CMAKE_LIBRARY_ARCHITECTURE}/pkgconfig")
+      endif ()
+    else ()
+      # not debian, check the FIND_LIBRARY_USE_LIB32_PATHS and FIND_LIBRARY_USE_LIB64_PATHS properties
+      get_property(uselib32 GLOBAL PROPERTY FIND_LIBRARY_USE_LIB32_PATHS)
+      if (uselib32 AND CMAKE_SIZEOF_VOID_P EQUAL 4)
+        list(APPEND _lib_dirs "lib32/pkgconfig")
+      endif ()
+      get_property(uselib64 GLOBAL PROPERTY FIND_LIBRARY_USE_LIB64_PATHS)
+      if (uselib64 AND CMAKE_SIZEOF_VOID_P EQUAL 8)
+        list(APPEND _lib_dirs "lib64/pkgconfig")
+      endif ()
+      get_property(uselibx32 GLOBAL PROPERTY FIND_LIBRARY_USE_LIBX32_PATHS)
+      if (uselibx32 AND CMAKE_INTERNAL_PLATFORM_ABI STREQUAL "ELF X32")
+        list(APPEND _lib_dirs "libx32/pkgconfig")
+      endif ()
+    endif ()
+  endif ()
+  if (CMAKE_SYSTEM_NAME STREQUAL "FreeBSD" AND NOT CMAKE_CROSSCOMPILING)
+    list(APPEND _lib_dirs "libdata/pkgconfig")
+  endif ()
+  list(APPEND _lib_dirs "lib/pkgconfig")
+  list(APPEND _lib_dirs "share/pkgconfig")
+
+  set(_extra_paths)
+  list(APPEND _extra_paths ${CMAKE_PREFIX_PATH})
+  list(APPEND _extra_paths ${CMAKE_FRAMEWORK_PATH})
+  list(APPEND _extra_paths ${CMAKE_APPBUNDLE_PATH})
+
+  # Check if directories exist and eventually append them to the
+  # pkgconfig path list
+  foreach (_prefix_dir ${_extra_paths})
+    foreach (_lib_dir ${_lib_dirs})
+      if (EXISTS "${_prefix_dir}/${_lib_dir}")
+        list(APPEND _pkgconfig_paths "${_prefix_dir}/${_lib_dir}")
+        list(REMOVE_DUPLICATES _pkgconfig_paths)
+      endif ()
+    endforeach ()
+  endforeach ()
+
+  set("${target_var}"
+      ${_pkgconfig_paths}
+      PARENT_SCOPE
+      )
+endfunction()
+
+# prevent repeating work if the main CMakeLists.txt already called
+# find_package(PkgConfig)
+if (NOT PKG_CONFIG_FOUND)
+  find_package(PkgConfig)
+endif ()
+
+if (PKG_CONFIG_FOUND)
+  pkg_check_modules(PC_MARGO_HG_SHIM QUIET margo-hg-shim)
+
+  find_path(
+      MARGO_HG_SHIM_INCLUDE_DIR
+      NAMES margo-hg-shim.h
+      PATHS ${PC_MARGO_HG_SHIM_INCLUDE_DIRS}
+      PATH_SUFFIXES include
+  )
+
+  find_library(
+      MARGO_HG_SHIM_LIBRARY
+      NAMES margo-hg-shim
+      PATHS ${PC_MARGO_HG_SHIM_LIBRARY_DIRS}
+  )
+
+  set(Margo_hg_shim_VERSION ${PC_MARGO_HG_SHIM_VERSION})
+else ()
+  find_path(
+      MARGO_HG_SHIMINCLUDE_DIR
+      NAMES margo-hg-shim.h
+      PATH_SUFFIXES include
+  )
+
+  find_library(MARGO_HG_SHIM_LIBRARY NAMES margo-hg-shim)
+
+  # even if pkg-config is not available, but Margo still installs a .pc file
+  # that we can use to retrieve library information from. Try to find it at all
+  # possible pkgconfig subfolders (depending on the system).
+  _get_pkgconfig_paths(_pkgconfig_paths)
+
+  find_file(_margo_hg_shim_pc_file margo-hg-shim.pc PATHS "${_pkgconfig_paths}")
+
+  if (NOT _margo_hg_shim_pc_file)
+    message(
+        FATAL_ERROR
+        "ERROR: Could not find 'margo_hg_shim.pc' file. Unable to determine library version"
+    )
+  endif ()
+
+  file(STRINGS "${_margo_hg_shim_pc_file}" _margo_hg_shim_pc_file_contents REGEX "Version: ")
+
+  if ("${_margo_hg_shim_pc_file_contents}" MATCHES "Version: ([0-9]+\\.[0-9]+\\.[0-9])")
+    set(Margo_hg_shim_VERSION ${CMAKE_MATCH_1})
+  else ()
+    message(FATAL_ERROR "ERROR: Failed to determine library version")
+  endif ()
+
+  unset(_pkg_config_paths)
+  unset(_margo_hg_shim_pc_file_contents)
+endif ()
+
+mark_as_advanced(MARGO_HG_SHIM_INCLUDE_DIR MARGO_HG_SHIM_LIBRARY)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(
+    Margo-hg-shim
+    FOUND_VAR Margo-hg-shim_FOUND
+    REQUIRED_VARS MARGO_HG_SHIM_LIBRARY MARGO_HG_SHIM_INCLUDE_DIR
+    VERSION_VAR Margo_hg_shim_VERSION
+)
+
+if (Margo-hg-shim_FOUND)
+  set(Margo_HG_SHIM_INCLUDE_DIRS ${MARGO_HG_SHIM_INCLUDE_DIR})
+  set(Margo_HG_SHIM_LIBRARIES ${MARGO_HG_SHIM_LIBRARY})
+  if (NOT TARGET Margo::Margo-hg-shim)
+    add_library(Margo::Margo-hg-shim UNKNOWN IMPORTED)
+    set_target_properties(
+        Margo::Margo-hg-shim
+        PROPERTIES IMPORTED_LOCATION "${MARGO_HG_SHIM_LIBRARY}"
+        INTERFACE_INCLUDE_DIRECTORIES "${MARGO_HG_SHIM_INCLUDE_DIR}"
+    )
+  endif ()
+endif ()

--- a/include/hermes/async_engine.hpp
+++ b/include/hermes/async_engine.hpp
@@ -681,14 +681,14 @@ private:
             // auto&& id = kv.first;
             auto&& descriptor = kv.second;
 
-            HERMES_DEBUG("**** registered: {}, {}, {}, {}, {}", 
+            detail::register_mercury_rpc(m_hg_class, descriptor, m_listen);
+
+            HERMES_DEBUG("**** registered: {}, {}, {}, {}, {}",
                     descriptor->m_id,
                     descriptor->m_mercury_id,
                     descriptor->m_name,
                     reinterpret_cast<void*>(descriptor->m_mercury_input_cb),
                     reinterpret_cast<void*>(descriptor->m_mercury_output_cb));
-
-            detail::register_mercury_rpc(m_hg_class, descriptor, m_listen);
         }
     }
 

--- a/include/hermes/detail/margo_compatibility.hpp
+++ b/include/hermes/detail/margo_compatibility.hpp
@@ -7,91 +7,11 @@
 #include <margo-hg-shim.h>
 #include <pthread.h>
 
-#define __MARGO_PROVIDER_ID_SIZE (sizeof(hg_id_t)/4)
-#define __MARGO_RPC_HASH_SIZE (__MARGO_PROVIDER_ID_SIZE * 3)
-
-#define MARGO_DEFAULT_PROVIDER_ID 0
-#define MARGO_MAX_PROVIDER_ID ((1 << (8*__MARGO_PROVIDER_ID_SIZE))-1)
-
 #endif // __MARGO
 
 namespace hermes {
 namespace detail {
 namespace margo {
-
-static inline void
-demux_id(hg_id_t in,
-         hg_id_t* base_id,
-         uint16_t *provider_id) {
-    /* retrieve low bits for provider */
-    *provider_id = 0;
-    *provider_id += (in & (((1<<(__MARGO_PROVIDER_ID_SIZE*8))-1)));
-
-    /* clear low order bits */
-    *base_id = (in >> (__MARGO_PROVIDER_ID_SIZE*8)) <<
-        (__MARGO_PROVIDER_ID_SIZE*8);
-
-    return;
-}
-
-static inline hg_id_t
-mux_id(hg_id_t base_id,
-       uint16_t provider_id) {
-    hg_id_t id;
-
-    id = (base_id >> (__MARGO_PROVIDER_ID_SIZE*8)) <<
-       (__MARGO_PROVIDER_ID_SIZE*8);
-    id |= provider_id;
-
-    return id;
-}
-
-static pthread_key_t rpc_breadcrumb_key;
-static pthread_once_t rpc_breadcrumb_key_once = PTHREAD_ONCE_INIT;
-
-/* sets the value of a breadcrumb, to be called just before issuing an RPC */
-static inline uint64_t
-breadcrumb_set(hg_id_t rpc_id) {
-    uint64_t* val;
-    uint64_t tmp;
-
-    (void) pthread_once(&rpc_breadcrumb_key_once,
-            []() {
-                (void) pthread_key_create(&rpc_breadcrumb_key, NULL);
-            }
-    );
-
-    if((val = reinterpret_cast<uint64_t*>(
-                    pthread_getspecific(rpc_breadcrumb_key))) == NULL) {
-        // key not set yet on this thread; we need to allocate a new one
-        // with all zeroes for initial value of breadcrumb and idx
-        val = reinterpret_cast<uint64_t*>(calloc(1, sizeof(*val)));
-
-        if(!val) {
-            return 0;
-        }
-    }
-
-    // NOTE: an rpc_id (after mux'ing) has provider in low order bits and
-    // base rpc_id in high order bits.  After demuxing, a base_id has zeroed
-    // out low bits.  So regardless of whether the rpc_id is a base_id or a
-    // mux'd id, either way we need to shift right to get either the
-    // provider id (or the space reserved for it) out of the way, then mask
-    // off 16 bits for use as a breadcrumb.
-    tmp = rpc_id >> (__MARGO_PROVIDER_ID_SIZE*8);
-    tmp &= 0xffff;
-
-    // clear low 16 bits of breadcrumb
-    *val = (*val >> 16) << 16;
-
-    // combine them, so that we have low order 16 of rpc id and high order
-    // bits of previous breadcrumb
-    *val |= tmp;
-
-    (void) pthread_setspecific(rpc_breadcrumb_key, val);
-
-    return *val;
-}
 
 static inline hg_id_t
 HG_Register_name(hg_class_t* hg_class, const char* func_name,

--- a/include/hermes/detail/margo_compatibility.hpp
+++ b/include/hermes/detail/margo_compatibility.hpp
@@ -4,6 +4,7 @@
 #ifndef __MARGO
 
 #include <mercury.h>
+#include <margo-hg-shim.h>
 #include <pthread.h>
 
 #define __MARGO_PROVIDER_ID_SIZE (sizeof(hg_id_t)/4)
@@ -91,6 +92,42 @@ breadcrumb_set(hg_id_t rpc_id) {
 
     return *val;
 }
+
+static inline hg_id_t
+HG_Register_name(hg_class_t* hg_class, const char* func_name,
+                 hg_rpc_cb_t rpc_cb) {
+    return HG_Register_name_for_margo(hg_class, func_name, rpc_cb);
+}
+static inline hg_return_t
+HG_Forward(hg_handle_t handle, hg_cb_t cb, void* args, hg_proc_cb_t proc_in, void* in_struct) {
+    return HG_Forward_to_margo(handle, cb, args, proc_in, in_struct);
+}
+
+static inline hg_return_t
+HG_Respond(hg_handle_t handle, hg_cb_t cb, void* args, hg_proc_cb_t proc_out, void* out_struct) {
+    return HG_Respond_to_margo(handle, cb, args, proc_out, out_struct);
+}
+
+static inline hg_return_t
+HG_Get_input(hg_handle_t handle, hg_proc_cb_t proc_in, void* in_struct) {
+    return HG_Get_input_from_margo(handle, proc_in, in_struct);
+}
+
+static inline hg_return_t
+HG_Free_input(hg_handle_t handle, hg_proc_cb_t proc_in, void* in_struct) {
+    return HG_Free_input_from_margo(handle, proc_in, in_struct);
+}
+
+static inline hg_return_t
+HG_Get_output(hg_handle_t handle, hg_proc_cb_t proc_out, void* out_struct) {
+    return HG_Get_output_from_margo(handle, proc_out, out_struct);
+}
+
+static inline hg_return_t
+HG_Free_output(hg_handle_t handle, hg_proc_cb_t proc_out, void* out_struct) {
+    return HG_Free_output_from_margo(handle, proc_out, out_struct);
+}
+
 
 } // namespace margo
 } // namespace detail

--- a/include/hermes/detail/margo_compatibility.hpp
+++ b/include/hermes/detail/margo_compatibility.hpp
@@ -14,40 +14,39 @@ namespace detail {
 namespace margo {
 
 static inline hg_id_t
-HG_Register_name(hg_class_t* hg_class, const char* func_name,
+register_name(hg_class_t* hg_class, const char* func_name,
                  hg_rpc_cb_t rpc_cb) {
     return HG_Register_name_for_margo(hg_class, func_name, rpc_cb);
 }
 static inline hg_return_t
-HG_Forward(hg_handle_t handle, hg_cb_t cb, void* args, hg_proc_cb_t proc_in, void* in_struct) {
+forward(hg_handle_t handle, hg_cb_t cb, void* args, hg_proc_cb_t proc_in, void* in_struct) {
     return HG_Forward_to_margo(handle, cb, args, proc_in, in_struct);
 }
 
 static inline hg_return_t
-HG_Respond(hg_handle_t handle, hg_cb_t cb, void* args, hg_proc_cb_t proc_out, void* out_struct) {
+respond(hg_handle_t handle, hg_cb_t cb, void* args, hg_proc_cb_t proc_out, void* out_struct) {
     return HG_Respond_to_margo(handle, cb, args, proc_out, out_struct);
 }
 
 static inline hg_return_t
-HG_Get_input(hg_handle_t handle, hg_proc_cb_t proc_in, void* in_struct) {
+get_input(hg_handle_t handle, hg_proc_cb_t proc_in, void* in_struct) {
     return HG_Get_input_from_margo(handle, proc_in, in_struct);
 }
 
 static inline hg_return_t
-HG_Free_input(hg_handle_t handle, hg_proc_cb_t proc_in, void* in_struct) {
+free_input(hg_handle_t handle, hg_proc_cb_t proc_in, void* in_struct) {
     return HG_Free_input_from_margo(handle, proc_in, in_struct);
 }
 
 static inline hg_return_t
-HG_Get_output(hg_handle_t handle, hg_proc_cb_t proc_out, void* out_struct) {
+get_output(hg_handle_t handle, hg_proc_cb_t proc_out, void* out_struct) {
     return HG_Get_output_from_margo(handle, proc_out, out_struct);
 }
 
 static inline hg_return_t
-HG_Free_output(hg_handle_t handle, hg_proc_cb_t proc_out, void* out_struct) {
+free_output(hg_handle_t handle, hg_proc_cb_t proc_out, void* out_struct) {
     return HG_Free_output_from_margo(handle, proc_out, out_struct);
 }
-
 
 } // namespace margo
 } // namespace detail

--- a/include/hermes/detail/mercury_utils.hpp
+++ b/include/hermes/detail/mercury_utils.hpp
@@ -3,10 +3,15 @@
 
 // C includes
 #include <mercury.h>
+#include <mercury_bulk.h>
 #include <mercury_log.h>
+
+// C++ includes
+#include <cassert>
 
 // project includes
 #include <hermes/logging.hpp>
+#include <hermes/make_unique.hpp>
 #include <hermes/request.hpp>
 #include <hermes/detail/address.hpp>
 #include <hermes/detail/execution_context.hpp>
@@ -53,16 +58,6 @@ initialize_mercury(const std::string& transport_prefix,
     if(hg_class == NULL) {
         throw std::runtime_error("Failed to initialize Mercury");
     }
-
-#ifdef HERMES_MARGO_COMPATIBLE_MODE
-    // set input offset to include Margo breadcrumbs information in Mercury
-    // requests
-    hg_return_t hret = HG_Class_set_input_offset(hg_class, sizeof(uint64_t));
-
-    // this should not ever fail
-    assert(hret == HG_SUCCESS);
-#endif // HERMES_MARGO_COMPATIBLE_MODE
-
     return hg_class;
 }
 
@@ -131,14 +126,15 @@ inline void
 register_mercury_rpc(hg_class_t* hg_class, 
                      const Descriptor& descriptor,
                      bool listen) {
-
-    hg_return_t ret = HG_Register(hg_class,
-                                  descriptor->m_mercury_id,
-                                  descriptor->m_mercury_input_cb,
-                                  descriptor->m_mercury_output_cb,
-                                  listen ? 
-                                    descriptor->m_handler : 
-                                    nullptr);
+    hg_return_t ret{};
+#ifdef HERMES_MARGO_COMPATIBLE_MODE
+    descriptor->m_mercury_id =
+            margo::HG_Register_name(hg_class, descriptor->m_name, nullptr);
+#else
+    ret = HG_Register(hg_class, descriptor->m_mercury_id,
+                      descriptor->m_mercury_input_cb,
+                      descriptor->m_mercury_output_cb,
+                      listen ? descriptor->m_handler : nullptr);
 
     HERMES_DEBUG2("    HG_Register(hg_class={}, hg_id={}, in_proc_cb={}, "
                   "out_proc_cb={}, rpc_cb={}) = {}",
@@ -153,6 +149,14 @@ register_mercury_rpc(hg_class_t* hg_class,
         throw std::runtime_error("Failed to register RPC '" +
                             std::string(descriptor->m_name) + "': " +
                             std::string(HG_Error_to_string(ret)));
+    }
+#endif
+    
+    if(descriptor->m_mercury_id == 0) {
+        throw std::runtime_error(
+                "Failed to register RPC: name '" + std::string(descriptor->m_name) +
+                "' : " + "id: '" + std::to_string(descriptor->m_mercury_id) +
+                "' is invalid");
     }
 
     if(!descriptor->m_requires_response) {
@@ -252,7 +256,11 @@ decode_mercury_input(hg_handle_t handle) {
     MercuryInput hg_input;
 
     // decode input
+#ifdef HERMES_MARGO_COMPATIBLE_MODE
+    hg_return_t ret = margo::HG_Get_input(handle, Request::mercury_in_proc_cb, &hg_input);
+#else
     hg_return_t ret = HG_Get_input(handle, &hg_input);
+#endif // HERMES_MARGO_COMPATIBLE_MODE
 
     if(ret != HG_SUCCESS) {
         throw std::runtime_error("Failed to decode request input data: " +
@@ -277,7 +285,11 @@ decode_mercury_output(hg_handle_t handle) {
     MercuryOutput hg_output;
 
     // decode output
+#ifdef HERMES_MARGO_COMPATIBLE_MODE
+    hg_return_t ret = margo::HG_Get_output(handle, Request::mercury_out_proc_cb, &hg_output);
+#else
     hg_return_t ret = HG_Get_output(handle, &hg_output);
+#endif // HERMES_MARGO_COMPATIBLE_MODE
 
     if(ret != HG_SUCCESS) {
         throw std::runtime_error("Failed to decode request output data: " +
@@ -395,7 +407,11 @@ post_to_mercury(ExecutionContext* ctx) {
 
             ctx->m_output_promise.set_value(RequestOutput(hg_output));
             // clean up resources consumed by this RPC
+#ifdef HERMES_MARGO_COMPATIBLE_MODE
+            margo::HG_Free_output(cbi->info.forward.handle, Request::mercury_out_proc_cb, &hg_output);
+#else
             HG_Free_output(cbi->info.forward.handle, &hg_output);
+#endif // HERMES_MARGO_COMPATIBLE_MODE
         }
 
         HG_Destroy(cbi->info.forward.handle);
@@ -409,40 +425,32 @@ post_to_mercury(ExecutionContext* ctx) {
     // just reuse the old one since the Mercury documentation states that 
     // this is safe to do
     if(ctx->m_handle == HG_HANDLE_NULL) {
-        // create a Mercury handle for the RPC and save it in the RPC's 
-        // execution context
-        ctx->m_handle = 
-            detail::create_mercury_handle(ctx->m_hg_context,
-                                          ctx->m_address->mercury_address(),
-                                          Request::mercury_id);
-    }
-
 #ifdef HERMES_MARGO_COMPATIBLE_MODE
-    const struct hg_info* hgi = HG_Get_info(ctx->m_handle);
-    hg_id_t id = margo::mux_id(hgi->id, MARGO_DEFAULT_PROVIDER_ID);
-
-    hg_return hret = HG_Reset(ctx->m_handle, hgi->addr, id);
-
-    if(hret != HG_SUCCESS) {
-        HERMES_ERROR("Failed to reset RPC handle");
-        return hret;
-    }
-
-    // add rpc breadcrumb to outbound request; this will be used to track
-    // rpc statistics
-    uint64_t* rpc_breadcrumb;
-
-    hret = HG_Get_input_buf(ctx->m_handle, (void**)&rpc_breadcrumb, NULL);
-
-    if(hret != HG_SUCCESS) {
-        HERMES_ERROR("Failed to retrieve RPC input buffer");
-        return hret;
-    }
-
-    uint64_t bc = margo::breadcrumb_set(hgi->id);
-    *rpc_breadcrumb = htole64(bc);
+        hg_id_t mercury_id = detail::registered_requests().at(Request::public_id)->m_mercury_id;
+        HERMES_DEBUG("Creating Mercury handle with id {}", mercury_id);
+#else
+        hg_id_t mercury_id = Request::mercury_id;
 #endif // HERMES_MARGO_COMPATIBLE_MODE
-
+        // create a Mercury handle for the RPC and save it in the RPC's
+        // execution context
+        ctx->m_handle = detail::create_mercury_handle(
+                ctx->m_hg_context, ctx->m_address->mercury_address(),
+                mercury_id);
+    }
+    
+#ifdef HERMES_MARGO_COMPATIBLE_MODE
+    hg_return_t ret = margo::HG_Forward(
+            // Mercury handle
+            ctx->m_handle,
+            // pointer to function callback
+            completion_callback,
+            // pointer to data passed to callback
+            reinterpret_cast<void*>(ctx),
+            // pointer to input proc function
+            Request::mercury_in_proc_cb,
+            // pointer to input structure
+            &ctx->m_mercury_input);
+#else
     hg_return_t ret = HG_Forward(
             // Mercury handle
             ctx->m_handle,
@@ -452,6 +460,7 @@ post_to_mercury(ExecutionContext* ctx) {
             reinterpret_cast<void*>(ctx),
             // pointer to input structure
             &ctx->m_mercury_input);
+#endif // HERMES_MARGO_COMPATIBLE_MODE
 
     HERMES_DEBUG2("HG_Forward(handle={}, cb={}, arg={}, input={}) = {}",
                   fmt::ptr(ctx->m_handle), 
@@ -531,6 +540,21 @@ template <typename Input, typename Output>
 inline void
 mercury_respond(request<Input>&& req, 
                 Output&& out) {
+#ifdef HERMES_MARGO_COMPATIBLE_MODE
+    // This is just a best effort response, we don't bother specifying
+    // a callback here for completion
+    hg_return_t ret = margo::HG_Respond(
+            // handle
+            req.m_handle,
+            // callback
+            NULL,
+            // arg
+            NULL,
+            // pointer to proc function
+            Output::mercury_out_proc_cb,
+            // output struct
+            &out);
+#else
 
     // This is just a best effort response, we don't bother specifying
     // a callback here for completion
@@ -543,6 +567,7 @@ mercury_respond(request<Input>&& req,
                             NULL,
                             // output struct
                             &out);
+#endif // HERMES_MARGO_COMPATIBLE_MODE
 
     HERMES_DEBUG2("HG_Respond(hg_handle={}, callback={}, arg={}, "
                   "out_struct={}) = {}", fmt::ptr(req.m_handle), "NULL", 

--- a/include/hermes/detail/request_descriptor.hpp
+++ b/include/hermes/detail/request_descriptor.hpp
@@ -36,7 +36,7 @@ class request_descriptor_base {
 
 public:
     request_descriptor_base(uint16_t id,
-                            const hg_id_t hg_id,
+                            hg_id_t hg_id,
                             const char* const name,
                             const bool requires_response,
                             const hg_proc_cb_t in_proc_cb,
@@ -60,7 +60,7 @@ protected:
 
 public:
     const uint16_t m_id;
-    const hg_id_t m_mercury_id;
+    hg_id_t m_mercury_id;
     const char* const m_name;
     const bool m_requires_response;
     const hg_proc_cb_t m_mercury_input_cb;
@@ -83,7 +83,7 @@ struct request_descriptor : public request_descriptor_base {
     constexpr static const auto public_id = Request::public_id;
 
     // RPC internal Mercury identifier
-    constexpr static const auto mercury_id = public_id;
+    hg_id_t mercury_id = 0;
 
     // RPC name
     constexpr static const auto name = Request::name;
@@ -101,7 +101,7 @@ struct request_descriptor : public request_descriptor_base {
 
 
     request_descriptor(uint16_t id,
-                       const hg_id_t hg_id,
+                       hg_id_t hg_id,
                        const char* const name,
                        const bool requires_response,
                        const hg_proc_cb_t in_proc_cb,

--- a/include/hermes/detail/request_registrar.hpp
+++ b/include/hermes/detail/request_registrar.hpp
@@ -43,7 +43,7 @@ public:
             // already registered, just ignore the request
             const auto& r = m_request_types.at(id);
 
-            if(mercury_id == r->m_mercury_id && name == r->m_name &&
+            if(name == r->m_name &&
                requires_response == r->m_requires_response &&
                mercury_in_proc_cb == r->m_mercury_input_cb &&
                mercury_out_proc_cb == r->m_mercury_output_cb) {

--- a/include/hermes/request.hpp
+++ b/include/hermes/request.hpp
@@ -10,6 +10,10 @@
 
 #include "logging.hpp"
 
+#ifdef HERMES_MARGO_COMPATIBLE_MODE
+#include <hermes/detail/margo_compatibility.hpp>
+#endif // HERMES_MARGO_COMPATIBLE_MODE
+
 namespace hermes {
 
 // forward declarations
@@ -128,7 +132,11 @@ public:
             hg_return_t ret = HG_SUCCESS;
 
             if(m_mercury_input) {
+#ifdef HERMES_MARGO_COMPATIBLE_MODE
+                ret = detail::margo::HG_Free_input(m_handle, m_mercury_input_cb, m_mercury_input.get());
+#else
                 ret = HG_Free_input(m_handle, m_mercury_input.get());
+#endif // HERMES_MARGO_COMPATIBLE_MODE
 
                 HERMES_DEBUG2("HG_Free_input({}, {}) = {}", 
                               fmt::ptr(m_handle), fmt::ptr(&m_mercury_input), 
@@ -149,6 +157,8 @@ private:
     std::unique_ptr<MercuryInput> m_mercury_input;
     std::unique_ptr<Input> m_input;
     bool m_requires_response;
+    constexpr static const auto m_mercury_input_cb =
+            Request::mercury_in_proc_cb;
 };
 
 

--- a/include/hermes/request.hpp
+++ b/include/hermes/request.hpp
@@ -133,12 +133,13 @@ public:
 
             if(m_mercury_input) {
 #ifdef HERMES_MARGO_COMPATIBLE_MODE
-                ret = detail::margo::HG_Free_input(m_handle, m_mercury_input_cb, m_mercury_input.get());
+                ret = detail::margo::free_input(m_handle, m_mercury_input_cb,
+                                                m_mercury_input.get());
 #else
                 ret = HG_Free_input(m_handle, m_mercury_input.get());
 #endif // HERMES_MARGO_COMPATIBLE_MODE
 
-                HERMES_DEBUG2("HG_Free_input({}, {}) = {}", 
+                HERMES_DEBUG2("margo::free_input({}, {}) = {}",
                               fmt::ptr(m_handle), fmt::ptr(&m_mercury_input), 
                               HG_Error_to_string(ret));
             }


### PR DESCRIPTION
This PR adds support for Margo's new shim library. This is necessary because Margo serialization is now differently handled causing Hermes' Margo compatibility layer to no longer work. The shim library now takes care of all serialization and it is no longer necessary to provide an RPC ID as this is done transparently by the library. It works without Argobots.

This has been tested with GekkoFS and Mercury v.2.3.0 and Margo v0.14.0.